### PR TITLE
Update test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,27 +17,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             python: "3.7"
             python-req: requirements_buster.txt
-            python-apt: 1.6.4
-            experimental: false
-          - os: ubuntu-20.04
-            python: "3.8"
-            python-req: requirements_bullseye.txt
             python-apt: 2.0.0
             experimental: false
           - os: ubuntu-20.04
             python: "3.9"
             python-req: requirements_bullseye.txt
             python-apt: 2.0.0
+            experimental: false
+          - os: ubuntu-22.04
+            python: "3.11"
+            python-req: requirements_bookworm.txt
+            python-apt: 2.3.0
             experimental: true
 
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Install Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -53,7 +53,7 @@ jobs:
           sudo -u postgres psql -c "create database piwheels_test" -c "\l"
 
       - name: Checkout piwheels
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |

--- a/requirements_bookworm.txt
+++ b/requirements_bookworm.txt
@@ -1,4 +1,4 @@
-pyzmq==25.0.2
+pyzmq==24.0.1
 configargparse==1.5.3
 voluptuous==0.12.2
 urwid==2.1.2

--- a/requirements_bookworm.txt
+++ b/requirements_bookworm.txt
@@ -1,0 +1,8 @@
+pyzmq==25.0.2
+configargparse==1.5.3
+voluptuous==0.12.2
+urwid==2.1.2
+sqlalchemy==1.4.46
+psycopg2==2.9.5
+chameleon==3.8.1
+python-dateutil==2.8.2

--- a/requirements_bullseye.txt
+++ b/requirements_bullseye.txt
@@ -1,4 +1,4 @@
-pyzmq==25.0.2
+pyzmq==20.0.0
 configargparse==0.13.0
 voluptuous==0.11.1
 urwid==2.0.1

--- a/requirements_bullseye.txt
+++ b/requirements_bullseye.txt
@@ -1,4 +1,4 @@
-pyzmq==17.1.2
+pyzmq==25.0.2
 configargparse==0.13.0
 voluptuous==0.11.1
 urwid==2.0.1

--- a/requirements_buster.txt
+++ b/requirements_buster.txt
@@ -1,4 +1,4 @@
-pyzmq==25.0.2
+pyzmq==17.1.2
 configargparse==0.13.0
 voluptuous==0.11.1
 urwid==2.0.1

--- a/requirements_buster.txt
+++ b/requirements_buster.txt
@@ -1,4 +1,4 @@
-pyzmq==17.1.2
+pyzmq==25.0.2
 configargparse==0.13.0
 voluptuous==0.11.1
 urwid==2.0.1


### PR DESCRIPTION
Python 3.7 test runs now on Ubuntu 20.04 since 18.04 runners are not available anymore: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

Added Python 3.10 and 3.11 tests on Ubuntu 22.04 and initial Debian Bookworm requirements.

Also updated the used actions' versions and pyzmq to fix all tests.